### PR TITLE
Add logging of LLM interactions

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,15 @@ Pydantic models describing the LLM responses live in `src/schemas.py`. The
 `FollowupOutput` model shows how to use `Literal` to constrain values returned
 by the language model. FastAPI routers for each agent are defined in their
 respective `router.py` modules and are collected by `src/agent.py`. The
-application entry point in `src/main.py` simply mounts these routers and adds
+application entry point in `src/main.py` simply mounts these routers, configures
+basic logging, and adds
 some basic middleware.
+
+## Logging
+
+Running the server creates an `app.log` file in the project root. The file is
+overwritten on each start and contains debug information including the prompts
+sent to the LLMs and their structured responses.
 
 ## Extending
 

--- a/src/agent_one/runner.py
+++ b/src/agent_one/runner.py
@@ -2,6 +2,9 @@ from agents import Runner
 
 from .agent import summary_agent, followup_agent
 from schemas import SummaryOutput, FollowupOutput
+import logging
+
+logger = logging.getLogger(__name__)
 
 
 class MultiAgentOutput(FollowupOutput):
@@ -11,14 +14,18 @@ class MultiAgentOutput(FollowupOutput):
 async def run(text: str) -> MultiAgentOutput:
     original_summary_instructions = summary_agent.instructions
     summary_agent.instructions = original_summary_instructions.replace("{{text}}", text)
+    logger.debug("SummaryAgent instructions: %s", summary_agent.instructions)
     run_summary = await Runner.run(summary_agent, input="")
+    logger.debug("SummaryAgent output: %s", run_summary.final_output.model_dump_json())
     summary_agent.instructions = original_summary_instructions
 
     summary_text = run_summary.final_output.summary
 
     original_followup_instructions = followup_agent.instructions
     followup_agent.instructions = original_followup_instructions.replace("{{summary}}", summary_text)
+    logger.debug("FollowupAgent instructions: %s", followup_agent.instructions)
     run_followup = await Runner.run(followup_agent, input="")
+    logger.debug("FollowupAgent output: %s", run_followup.final_output.model_dump_json())
     followup_agent.instructions = original_followup_instructions
 
     return MultiAgentOutput(

--- a/src/logging_config.py
+++ b/src/logging_config.py
@@ -1,0 +1,16 @@
+import logging
+from pathlib import Path
+
+
+def setup_logging(log_file: str = "app.log") -> None:
+    """Configure root logger to write detailed logs to file."""
+    log_path = Path(log_file).resolve()
+
+    logging.basicConfig(
+        level=logging.DEBUG,
+        format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        handlers=[
+            logging.FileHandler(log_path, mode="w"),
+            logging.StreamHandler()
+        ],
+    )

--- a/src/main.py
+++ b/src/main.py
@@ -4,6 +4,11 @@ from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import RedirectResponse
 
+from logging_config import setup_logging
+
+# configure logging before creating the FastAPI application
+setup_logging()
+
 from agent import register_endpoints
 
 app = FastAPI(


### PR DESCRIPTION
## Summary
- configure application logging with a new `logging_config` module
- initialise logging in `src/main.py`
- log prompts and responses in `agent_one.runner`
- document logging behaviour in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6842c23ccc08832181f040862118d39e